### PR TITLE
Add prefill support to DecodeStream

### DIFF
--- a/bindings/python/py_src/tokenizers/decoders/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/decoders/__init__.pyi
@@ -1,11 +1,19 @@
 # Generated content DO NOT EDIT
+from typing import List, Dict, Optional
 class DecodeStream:
     """
     Class needed for streaming decode
 
     """
-    def __init__(self, skip_special_tokens):
+    def __init__(self, skip_special_tokens, prefills: Optional[List[List[int]]] = None):
         pass
+
+    def step(self, tokenizer, inputs: Dict[str, int]) -> Dict[str, Optional[str]]:
+        pass
+
+    @property
+    def prefill_hashes(self) -> List[str]:
+        ...
 
 class Decoder:
     """

--- a/bindings/python/py_src/tokenizers/decoders/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/decoders/__init__.pyi
@@ -1,19 +1,11 @@
 # Generated content DO NOT EDIT
-from typing import List, Dict, Optional
 class DecodeStream:
     """
     Class needed for streaming decode
 
     """
-    def __init__(self, skip_special_tokens, prefills: Optional[List[List[int]]] = None):
+    def __init__(self, skip_special_tokens=True):
         pass
-
-    def step(self, tokenizer, inputs: Dict[str, int]) -> Dict[str, Optional[str]]:
-        pass
-
-    @property
-    def prefill_hashes(self) -> List[str]:
-        ...
 
 class Decoder:
     """

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -707,7 +707,7 @@ impl PyDecodeStream {
                             &mut state.ids,
                             &mut state.prefix,
                             &mut state.prefix_index,
-                        ).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("decode error: {}", e)))?;;
+                        ).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("decode error: {}", e)))?;
                     output.insert(hash, res);
                 }
                 Ok(StepOutput::Map(output))
@@ -736,7 +736,7 @@ impl PyDecodeStream {
                         &mut state.ids,
                         &mut state.prefix,
                         &mut state.prefix_index,
-                    ).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("decode error: {}", e)))?;;
+                    ).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("decode error: {}", e)))?;
 
                 Ok(StepOutput::Single(res))
             }

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -603,28 +603,12 @@ impl Decoder for PyDecoderWrapper {
     }
 }
 
-/// Decoders Module
-#[pymodule]
-pub fn decoders(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<PyDecoder>()?;
-    m.add_class::<PyByteLevelDec>()?;
-    m.add_class::<PyReplaceDec>()?;
-    m.add_class::<PyWordPieceDec>()?;
-    m.add_class::<PyByteFallbackDec>()?;
-    m.add_class::<PyFuseDec>()?;
-    m.add_class::<PyStrip>()?;
-    m.add_class::<PyMetaspaceDec>()?;
-    m.add_class::<PyBPEDecoder>()?;
-    m.add_class::<PyCTCDecoder>()?;
-    m.add_class::<PySequenceDecoder>()?;
-    m.add_class::<PyDecodeStream>()?;
-    Ok(())
-}
 
 /// Class needed for streaming decode
 ///
 #[pyclass(module = "tokenizers.decoders", name = "DecodeStream")]
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
 pub struct PyDecodeStream {
     /// Regular decode option that is kept throughout.
     skip_special_tokens: bool,
@@ -634,7 +618,8 @@ pub struct PyDecodeStream {
     prefill_hashes: Vec<String>,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "state")]
 struct PyDecodeState {
     ids: Vec<u32>,
     prefix: String,
@@ -774,6 +759,26 @@ impl PyDecodeStream {
         self.prefill_hashes.clone()
     }
 }
+
+
+/// Decoders Module
+#[pymodule]
+pub fn decoders(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyDecoder>()?;
+    m.add_class::<PyByteLevelDec>()?;
+    m.add_class::<PyReplaceDec>()?;
+    m.add_class::<PyWordPieceDec>()?;
+    m.add_class::<PyByteFallbackDec>()?;
+    m.add_class::<PyFuseDec>()?;
+    m.add_class::<PyStrip>()?;
+    m.add_class::<PyMetaspaceDec>()?;
+    m.add_class::<PyBPEDecoder>()?;
+    m.add_class::<PyCTCDecoder>()?;
+    m.add_class::<PySequenceDecoder>()?;
+    m.add_class::<PyDecodeStream>()?;
+    Ok(())
+}
+
 
 #[cfg(test)]
 mod test {

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -709,7 +709,7 @@ impl PyDecodeStream {
                             &mut state.ids,
                             &mut state.prefix,
                             &mut state.prefix_index,
-                        )?;
+                        ).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("decode error: {}", e)))?;;
                     }
 
                     output.insert(hash, res);
@@ -739,7 +739,7 @@ impl PyDecodeStream {
                         &mut state.ids,
                         &mut state.prefix,
                         &mut state.prefix_index,
-                    )?;
+                    ).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("decode error: {}", e)))?;;
                 }
 
                 Ok(StepOutput::Single(res))

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -746,7 +746,6 @@ impl PyDecodeStream {
                 Ok(StepOutput::Single(res))
                 }
             }
-        }
     }
 
     #[getter]

--- a/bindings/python/src/decoders.rs
+++ b/bindings/python/src/decoders.rs
@@ -629,14 +629,12 @@ pub struct PyDecodeStream {
     /// Regular decode option that is kept throughout.
     skip_special_tokens: bool,
     prefills: Vec<Vec<u32>>,
-    #[serde(skip)]
     states: Vec<PyDecodeState>,
-    #[serde(skip)]
     hash_to_index: std::collections::HashMap<String, usize>,
     prefill_hashes: Vec<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 struct PyDecodeState {
     ids: Vec<u32>,
     prefix: String,

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -427,6 +427,7 @@ class TestTokenizer:
         assert stream.step(tokenizer, {"": [1]}) == {"":" This"}
         assert stream.step(tokenizer, {"": [1, 0, 3, 4, 5, 6]}) == {"": "<0x20>"}
         stream.finish()
+        print(stream)
         assert stream.step(tokenizer, {"": [6, 7, 8]}) == {"": "ë"}
 
 

--- a/bindings/python/tests/bindings/test_tokenizer.py
+++ b/bindings/python/tests/bindings/test_tokenizer.py
@@ -422,14 +422,13 @@ class TestTokenizer:
         tokenizer = Tokenizer(Unigram(vocab, 0, byte_fallback=False))
         tokenizer.decoder = DecoderMetaspace()
         stream = DecodeStream(skip_special_tokens=False)
-        assert stream.step(tokenizer, [1]) ==  "This"
-        assert stream.step(tokenizer, [1]) ==  " This"
-        assert stream.step(tokenizer, {"": [1]}) == {"":" This"}
+        assert stream.step(tokenizer, [1]) == "This"
+        assert stream.step(tokenizer, [1]) == " This"
+        assert stream.step(tokenizer, {"": [1]}) == {"": " This"}
         assert stream.step(tokenizer, {"": [1, 0, 3, 4, 5, 6]}) == {"": "<0x20>"}
         stream.finish()
         print(stream)
         assert stream.step(tokenizer, {"": [6, 7, 8]}) == {"": "ë"}
-
 
     def test_get_vocab(self):
         tokenizer = Tokenizer(BPE())

--- a/tokenizers/src/tokenizer/mod.rs
+++ b/tokenizers/src/tokenizer/mod.rs
@@ -911,6 +911,15 @@ where
     pub fn decode_stream(&self, skip_special_tokens: bool) -> DecodeStream<'_, M, N, PT, PP, D> {
         DecodeStream::new(self, skip_special_tokens)
     }
+
+    /// DecodeStream with prefills
+    pub fn decode_stream_with_prefills(
+        &self,
+        skip_special_tokens: bool,
+        prefills: Vec<Vec<u32>>,
+    ) -> Result<DecodeStream<'_, M, N, PT, PP, D>> {
+        DecodeStream::new_with_prefills(self, skip_special_tokens, prefills)
+    }
 }
 
 /// DecodeStream will keep the state necessary to produce individual chunks of
@@ -1017,24 +1026,30 @@ pub struct DecodeStream<'tok, M, N, PT, PP, D> {
     tokenizer: &'tok TokenizerImpl<M, N, PT, PP, D>,
     /// Regular decode option that is kept throughout.
     skip_special_tokens: bool,
-    /// A temporary buffer of the necessary token_ids needed
-    /// to produce valid string chunks.
-    /// This typically contains 3 parts:
-    ///  - read
-    ///  - prefix
-    ///  - rest
-    ///
-    /// Read is the bit necessary to surround the prefix
-    /// so decoding the whole ids produces a valid prefix.
-    /// Prefix is the previously produced string, kept around to trim off of
-    /// the next valid chunk
+    /// Each decoding state associated to a given prefill.
+    states: Vec<DecodeState>,
+    /// Mapping between the prefill hash and its index within `states`
+    hash_to_index: std::collections::HashMap<String, usize>,
+    /// Stored hashes to return to the caller
+    prefill_hashes: Vec<String>,
+}
+
+#[derive(Clone)]
+struct DecodeState {
     ids: Vec<u32>,
-    /// The previously returned chunk that needs to be discarded from the
-    /// decoding of the current ids to produce the next chunk
     prefix: String,
-    /// The index within the ids corresponding to the prefix so we can drain
-    /// correctly
     prefix_index: usize,
+}
+
+fn compute_prefill_hash(ids: &[u32]) -> String {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+    let mut hash = FNV_OFFSET;
+    for &id in ids {
+        hash ^= id as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    format!("{:016x}", hash)
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -1052,25 +1067,87 @@ where
     D: Decoder,
 {
     fn new(tokenizer: &'tok TokenizerImpl<M, N, PT, PP, D>, skip_special_tokens: bool) -> Self {
+        let state = DecodeState { ids: vec![], prefix: String::new(), prefix_index: 0 };
+        let hash = compute_prefill_hash(&[]);
         Self {
             tokenizer,
-            ids: vec![],
             skip_special_tokens,
-            prefix: "".to_string(),
-            prefix_index: 0,
+            states: vec![state],
+            hash_to_index: std::iter::once((hash.clone(), 0)).collect(),
+            prefill_hashes: vec![hash],
         }
     }
 
+    fn new_with_prefills(
+        tokenizer: &'tok TokenizerImpl<M, N, PT, PP, D>,
+        skip_special_tokens: bool,
+        prefills: Vec<Vec<u32>>,
+    ) -> Result<Self> {
+        let mut states = Vec::new();
+        let mut prefill_hashes = Vec::new();
+        let mut hash_to_index = std::collections::HashMap::new();
+        for (i, prefill) in prefills.into_iter().enumerate() {
+            let mut state = DecodeState { ids: vec![], prefix: String::new(), prefix_index: 0 };
+            for id in &prefill {
+                let _ = step_decode_stream(
+                    tokenizer,
+                    *id,
+                    skip_special_tokens,
+                    &mut state.ids,
+                    &mut state.prefix,
+                    &mut state.prefix_index,
+                )?;
+            }
+            let hash = compute_prefill_hash(&prefill);
+            hash_to_index.insert(hash.clone(), i);
+            prefill_hashes.push(hash);
+            states.push(state);
+        }
+        Ok(Self {
+            tokenizer,
+            skip_special_tokens,
+            states,
+            hash_to_index,
+            prefill_hashes,
+        })
+    }
+
+    pub fn prefill_hashes(&self) -> &Vec<String> {
+        &self.prefill_hashes
+    }
+
     /// See [`DecodeStream`]
-    pub fn step(&mut self, id: u32) -> Result<Option<String>> {
-        step_decode_stream(
-            self.tokenizer,
-            id,
-            self.skip_special_tokens,
-            &mut self.ids,
-            &mut self.prefix,
-            &mut self.prefix_index,
-        )
+    pub fn step(
+        &mut self,
+        inputs: std::collections::HashMap<String, u32>,
+    ) -> Result<std::collections::HashMap<String, Option<String>>> {
+        let mut output = std::collections::HashMap::new();
+        for (hash, id) in inputs {
+            if let Some(&idx) = self.hash_to_index.get(&hash) {
+                let state = &mut self.states[idx];
+                let res = step_decode_stream(
+                    self.tokenizer,
+                    id,
+                    self.skip_special_tokens,
+                    &mut state.ids,
+                    &mut state.prefix,
+                    &mut state.prefix_index,
+                )?;
+                output.insert(hash, res);
+            }
+        }
+        Ok(output)
+    }
+
+    /// Convenience method when only a single state is used
+    pub fn step_token(&mut self, id: u32) -> Result<Option<String>> {
+        if let Some(hash) = self.prefill_hashes.get(0).cloned() {
+            let mut map = std::collections::HashMap::new();
+            map.insert(hash.clone(), id);
+            Ok(self.step(map)?.remove(&hash).unwrap())
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/tokenizers/tests/stream.rs
+++ b/tokenizers/tests/stream.rs
@@ -54,7 +54,7 @@ fn test_decode_stream_step_no_panic() {
 
     // "A B C D E F G H I J"
     let mut decode_stream = tokenizer.decode_stream(false);
-    assert_eq!(decode_stream.step(32).unwrap(), Some("A".to_string()));
+    assert_eq!(decode_stream.step([32]).unwrap(), Some("A".to_string()));
     assert_eq!(decode_stream.step(426).unwrap(), Some(" B".to_string()));
     assert_eq!(decode_stream.step(356).unwrap(), Some(" C".to_string()));
     assert_eq!(decode_stream.step(423).unwrap(), Some(" D".to_string()));

--- a/tokenizers/tests/stream.rs
+++ b/tokenizers/tests/stream.rs
@@ -54,7 +54,7 @@ fn test_decode_stream_step_no_panic() {
 
     // "A B C D E F G H I J"
     let mut decode_stream = tokenizer.decode_stream(false);
-    assert_eq!(decode_stream.step([32]).unwrap(), Some("A".to_string()));
+    assert_eq!(decode_stream.step(32).unwrap(), Some("A".to_string()));
     assert_eq!(decode_stream.step(426).unwrap(), Some(" B".to_string()));
     assert_eq!(decode_stream.step(356).unwrap(), Some(" C".to_string()));
     assert_eq!(decode_stream.step(423).unwrap(), Some(" D".to_string()));


### PR DESCRIPTION
## Summary
- add multiple-state support for DecodeStream via prefill lists
- expose `decode_stream_with_prefills` and hashed state tracking
- update python bindings and tests to handle dictionary-based streaming decode

## Testing
- `cargo test` *(fails: could not fetch crates)*
- `pytest` *(fails: 18 errors during collection)*
